### PR TITLE
Firefox: Current tab's Toolbar theme fix in Mixed Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,9 @@ Changelog
 ---
 
 # Unreleased
-# 15.0.1 [Firefox: Theming Bug Fixes]
-- Fix tabs not being randomized when creating tabs rapidly in mixed mode.
-- Fixes text selection & scrollbar not loading appropriately with their individual tab in mixed mode.
-- Fixes text selection & scrollbar not loading appropriately with their individual tab in mixed mode.
-- Appropriate theme for *options page* for each tab loads correctly in mixed mode.
-- Fixes initialization of a theme, when closing and reopening a browser.
-- Mitigates favicon & other theming components to stay themed in mixed mode.
-- Fixes search bar widget toggling in *Mixed Mode* reverting all tabs back to using a single theme.
+# 15.0.3 [Firefox: Theming Bug Fixes]
+- Fixes incorrect toolbar theme in *mixed mode* when rapidly creating tabs.([#77](https://github.com/doki-theme/doki-theme-web/issues/77))
+- Fixes incorrect toolbar theme in *mixed mode* when toggling search widget.([#77](https://github.com/doki-theme/doki-theme-web/issues/77))
 
 # 15.0.2 [Firefox History Sidebar Theming]
 

--- a/firefoxThemes/manifest.json
+++ b/firefoxThemes/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Doki Theme for Firefox",
   "short_name": "Doki Theme",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "description": "A theme collection of girls from various anime, manga, and visual novels series.",
   "manifest_version": 2,
   "icons": {

--- a/firefoxThemes/package.json
+++ b/firefoxThemes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doki-theme-firefox",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "description": "A theme collection of girls from various anime, manga, and visual novels series.",
   "main": "index.js",
   "repository": "https://github.com/doki-theme/doki-theme-web",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The current active tab's toolbar theme becomes completely different from the tab's overall theme in Mixed Mode. This pull request corrects this issue.

#### Description
<!-- Describe your changes in detail -->
Originally, the toolbar theme of the **current tab** uses the very **last tab's theme** instead of currently active tab's theme. These changes makes sure to only set the toolbar theme of the currently active tab that the user is currently utilizing. 
*See issue #77  for more info*

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #77 .

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] I updated the version (base package.json and re-built the master extension).
- [x] I updated the changelog with the new functionality.
